### PR TITLE
Fix priority lattice initialization

### DIFF
--- a/include/lattices/priority_lattice.hpp
+++ b/include/lattices/priority_lattice.hpp
@@ -22,7 +22,7 @@ struct PriorityValuePair {
   P priority;
   V value;
 
-  PriorityValuePair(P p = 1000000, V v = {}) : priority(p), value(v) {}
+  PriorityValuePair(P p = INT_MAX, V v = {}) : priority(p), value(v) {}
 
   unsigned size() { return sizeof(P) + value.size(); }
 };

--- a/include/lattices/priority_lattice.hpp
+++ b/include/lattices/priority_lattice.hpp
@@ -22,6 +22,7 @@ struct PriorityValuePair {
   P priority;
   V value;
 
+  // Initialize at a high value since the merge logic is taking the minimum
   PriorityValuePair(P p = INT_MAX, V v = {}) : priority(p), value(v) {}
 
   unsigned size() { return sizeof(P) + value.size(); }

--- a/include/lattices/priority_lattice.hpp
+++ b/include/lattices/priority_lattice.hpp
@@ -22,7 +22,7 @@ struct PriorityValuePair {
   P priority;
   V value;
 
-  PriorityValuePair(P p = 0, V v = {}) : priority(p), value(v) {}
+  PriorityValuePair(P p = 1000000, V v = {}) : priority(p), value(v) {}
 
   unsigned size() { return sizeof(P) + value.size(); }
 };


### PR DESCRIPTION
Previously, the priority lattice's priority is initialized to 0. But instead we should initialized it to be a large number because the merge logic is taking the minimum. Otherwise with positive priorities the value will never get merged.