### PR TITLE
copy serializers for set and lww

### DIFF
--- a/include/lattices/core_lattices.hpp
+++ b/include/lattices/core_lattices.hpp
@@ -87,6 +87,18 @@ class SetLattice : public Lattice<set<T>> {
 
     return SetLattice<T>(res);
   }
+  
+  inline string serialize() {
+  SetValue set_value;
+  for (const string& val : this->element) {
+    set_value.add_values(val);
+  }
+
+  string serialized;
+  set_value.SerializeToString(&serialized);
+  return serialized;
+}
+
 };
 
 template <typename T>

--- a/include/lattices/lww_pair_lattice.hpp
+++ b/include/lattices/lww_pair_lattice.hpp
@@ -55,6 +55,16 @@ class LWWPairLattice : public Lattice<TimestampValuePair<T>> {
   LWWPairLattice(const TimestampValuePair<T>& p) :
       Lattice<TimestampValuePair<T>>(p) {}
   MaxLattice<unsigned> size() { return {this->element.size()}; }
+
+  inline string serialize() {
+  LWWValue lww_value;
+  lww_value.set_timestamp(this->element.timestamp);
+  lww_value.set_value(this->element.value);
+
+  string serialized;
+  lww_value.SerializeToString(&serialized);
+  return serialized;
+}
 };
 
 #endif  // INCLUDE_LATTICES_LWW_PAIR_LATTICE_HPP_


### PR DESCRIPTION
I copied the serializers for SetLattice and LWWPairLattice from common/include/common.hpp to common/common/include/lattices files and made them class methods.