### PR TITLE
Update zmqcpp version and add max socket macro

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -33,6 +33,7 @@ const string kMetadataIdentifier = "ANNA_METADATA";
 const string kMetadataDelimiter = "|";
 const char kMetadataDelimiterChar = '|';
 const string kMetadataTypeCacheIP = "cache_ip";
+const unsigned kMaxSocketNumber = 10000;
 
 inline void split(const string& s, char delim, vector<string>& elems) {
   std::stringstream ss(s);

--- a/vendor/zeromqcpp/CMakeLists.txt
+++ b/vendor/zeromqcpp/CMakeLists.txt
@@ -11,7 +11,7 @@ INCLUDE(ExternalProject)
 
 EXTERNALPROJECT_ADD(zeromqcpp
     GIT_REPOSITORY "https://github.com/zeromq/cppzmq.git"
-    GIT_TAG "v4.2.3"
+    GIT_TAG "v4.3.0"
     BUILD_IN_SOURCE 1
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
The previous version of zmqcpp doesn't allow us to set the context's max socket number.
By default, the max socket connection for a context is 1024, but to support a large number of connection to function executors, we need to increase this limit.

Switching to 4.3.0 allows us to set the limit to a higher number.