### PR TITLE
Add references field for FunctionCall and DagCall

### DIFF
--- a/mock/mock_zmq_utils.cpp
+++ b/mock/mock_zmq_utils.cpp
@@ -18,7 +18,14 @@ void MockZmqUtil::send_string(const string &s, zmq::socket_t *socket) {
   sent_messages.push_back(s);
 }
 
-string MockZmqUtil::recv_string(zmq::socket_t *socket) { return ""; }
+string MockZmqUtil::recv_string(zmq::socket_t *socket) {
+  if(responses.empty()){
+    return "";
+  }
+  string response = responses[0];
+  responses.pop_front();
+  return response;
+}
 
 int MockZmqUtil::poll(long timeout, vector<zmq::pollitem_t> *items) {
   return 0;

--- a/mock/mock_zmq_utils.hpp
+++ b/mock/mock_zmq_utils.hpp
@@ -20,6 +20,7 @@
 class MockZmqUtil : public ZmqUtilInterface {
  public:
   vector<string> sent_messages;
+  std::deque<string> responses;
 
   virtual void send_string(const string &s, zmq::socket_t *socket);
   virtual string recv_string(zmq::socket_t *socket);

--- a/proto/cloudburst.proto
+++ b/proto/cloudburst.proto
@@ -94,7 +94,8 @@ message Value {
 
 // A request to execute a pre-registered function a single time.
 message FunctionCall {
-  // The name of the fucntion to execute.
+
+  // The name of the function to execute.
   string name = 1;
 
   // A unique ID used to match asynchronous requests to responses.
@@ -110,6 +111,9 @@ message FunctionCall {
 
   // Specify what consistency mode this function should be executed in.
   ConsistencyType consistency = 5;
+
+  // Specify what keys are referenced from the KVS
+  repeated string references = 6;
 }
 
 // A serialized representation of a Cloudburst DAG, which consists of a set of

--- a/proto/cloudburst.proto
+++ b/proto/cloudburst.proto
@@ -181,6 +181,9 @@ message Dag {
 message Arguments {
   // The set of arguments.
   repeated Value values = 1;
+
+  // Specify what keys are referenced from the KVS
+  repeated string references = 2;
 }
 
 // A request for a single execution of a previously registered DAG of
@@ -212,9 +215,6 @@ message DagCall {
 
   // The name of the DAG to continue this request with.
   Continuation continuation = 7;
-
-  // Specify what keys are referenced from the KVS
-  repeated string references = 8;
 }
 
 // A message used to respond to most kinds of user requests.

--- a/proto/cloudburst.proto
+++ b/proto/cloudburst.proto
@@ -175,6 +175,9 @@ message DagCall {
   // A logical unique ID associated with the requesting client. This can
   // persist across requests and is used for causal metadata.
   string client_id = 6;
+
+  // Specify what keys are referenced from the KVS
+  repeated string references = 7;
 }
 
 // A message used to respond to most kinds of user requests.


### PR DESCRIPTION
Adds a repeated string field `references` which should contain the argument names referenced from the KVS in the call.